### PR TITLE
ENG-6913 Support upgrade of Release 10.0/10.1 (Helm installation) to 10.2 using operator on On-Prem

### DIFF
--- a/xl-infra/blueprint.yaml
+++ b/xl-infra/blueprint.yaml
@@ -16,6 +16,8 @@ spec:
           value: Openshift
         - label: AWS EKS
           value: AwsEKS
+        - label: Plain multi-node K8s cluster
+          value: PlainK8SCluster
       saveInXlvals: true
       description: "The flavour of Kubernetes to deploy or undeploy the digitalai Devops Platform to. Only the listed options are supported"
 


### PR DESCRIPTION
ENG-6913 Support upgrade of Release 10.0/10.1 (Helm installation) to 10.2 using operator on On-Prem

Story: https://digitalai.atlassian.net/browse/ENG-6913
- Updated xl-infra blueprint file with on-prem k8s support
