### PR TITLE
Support upgrade of Deploy 10.0/10.1 (Helm installation) to 10.2/10.3/10.4 using operator on GCP GKE

### DIFF
--- a/xl-infra/blueprint.yaml
+++ b/xl-infra/blueprint.yaml
@@ -18,6 +18,9 @@ spec:
           value: AwsEKS
         - label: Plain multi-node K8s cluster
           value: PlainK8SCluster
+        - label: Google Kubernetes Engine
+          value: GoogleGKE
+
       saveInXlvals: true
       description: "The flavour of Kubernetes to deploy or undeploy the digitalai Devops Platform to. Only the listed options are supported"
 


### PR DESCRIPTION

https://digitalai.atlassian.net/browse/ENG-8064

I have tested the Support upgrade of Deploy Helm to the operator upgrade path on the GCP GKE Platform.
