### PR TITLE
ENG-8807 XL Op upgrade doesn't work correctly for OpenShift if to point to config in ~/.kube/config

### DIFF
--- a/xl-infra/blueprint.yaml
+++ b/xl-infra/blueprint.yaml
@@ -3,7 +3,7 @@ kind: Blueprint
 metadata:
   name: XL OP
   description: |
-    This blueprint deploys dspoljaric Deploy operator, DAI Release operator, and XL-k8s-foundation into an existing Kubernetes installation (local single-node Kubernetes, on-premises multi-node Kubernetes cluster, Google Kubernetes Engine cluster, or Amazon EKS cluster).
+    This blueprint deploys DAI Deploy operator, DAI Release operator, and XL-k8s-foundation into an existing Kubernetes installation (local single-node Kubernetes, on-premises multi-node Kubernetes cluster, Google Kubernetes Engine cluster, or Amazon EKS cluster).
   author: digitalai
   version: 1.0
 spec:

--- a/xl-infra/blueprint.yaml
+++ b/xl-infra/blueprint.yaml
@@ -3,7 +3,7 @@ kind: Blueprint
 metadata:
   name: XL OP
   description: |
-    This blueprint deploys DAI Deploy operator, DAI Release operator, and XL-k8s-foundation into an existing Kubernetes installation (local single-node Kubernetes, on-premises multi-node Kubernetes cluster, Google Kubernetes Engine cluster, or Amazon EKS cluster).
+    This blueprint deploys dspoljaric Deploy operator, DAI Release operator, and XL-k8s-foundation into an existing Kubernetes installation (local single-node Kubernetes, on-premises multi-node Kubernetes cluster, Google Kubernetes Engine cluster, or Amazon EKS cluster).
   author: digitalai
   version: 1.0
 spec:
@@ -73,6 +73,7 @@ spec:
       type: SecretEditor
       prompt: "Provide authentication token for the existing service account:"
       promptIf: !expr "K8sSetup != 'AwsEKS' && K8sAuthentication == 'Token'"
+      default: !expr "(UseKubeconfig && k8sConfig('IsUserTokenAvailable')) ? k8sConfig('UserToken') : ''"
       saveInXlvals: true
       ignoreIfSkipped: true
       replaceAsIs: true


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/ENG-8807

Changes in this PR depend on [changes in blueprint-cli](https://github.com/xebialabs/blueprint-cli/pull/8) that have to be merged in first.