### PR TITLE
S-87867 For Deploy, support separate configuration for main and report DB

### DIFF
--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -552,9 +552,9 @@ spec:
         XLR_DB_URL: jdbc:postgresql://<xlr-db-host>:5432/<xlr-database-name>
         XLR_DB_USER: <xlr-username>
         XLR_DB_PASS: <xlr-password>
-        XLR_REPORT_DB_URL: jdbc:postgresql://<xlr-report-db-host>:5432/<xl-report-database-name>
-        XLR_REPORT_DB_USER: <xl-report-username>
-        XLR_REPORT_DB_PASS: <xl-report-password>
+        XLR_REPORT_DB_URL: jdbc:postgresql://<xlr-report-db-host>:5432/<xlr-report-database-name>
+        XLR_REPORT_DB_USER: <xlr-report-username>
+        XLR_REPORT_DB_PASS: <xlr-report-password>
     - name: PostgresqlExternalConfigDeploy
       type: Editor
       saveInXlvals: true
@@ -567,6 +567,9 @@ spec:
         XL_DB_URL: jdbc:postgresql://<xld-db-host>:5432/<xlr-database-name>
         XL_DB_USERNAME: <xld-username>
         XL_DB_PASSWORD: <xld-password>
+        XL_REPORT_DB_URL: jdbc:postgresql://<xld-report-db-host>:5432/<xld-report-database-name>
+        XL_REPORT_DB_USER: <xld-report-username>
+        XL_REPORT_DB_PASS: <xld-report-username>
     - name: EnableRabbitmq
       type: Confirm
       default: true


### PR DESCRIPTION
- D-21723 Split ExternalOidcConf for deploy and release (#78)
- S-87133 Improvements for xl op command and xl op check (#79)
- S-87307 D-22641 D-22646 Ingress fixes (#81)
- D-22598 DwD - fix Unexpected Escape Sequence: ['\x1b' 'O'] (#80)
- D 22682 Minor Blueprints and XL CLI fixes
- D-22637 Fix upgrade with missing PreserveCrValues (#84)
- D-22615 [DwD] Fixed problem with Installing Deploy & Release with OIDC enabled with embedded keycloak (#86)
- S 84985 Add question for spec.Persistence.AccessMode (#90)
- S-87141 S-87688 description improvements
- D-22820 Add warning if TLS secret is missing (#92)
- Dependencies were automatically synced.
- Dependencies were automatically synced.
- D-22847 fix secret check without existing namespace (#94)
- update nexus host
- D-22867 recheck answers file (#95)
- D-22871 on release external DB and MQ are not correctly mapped (#97)
- D-22878 Fix wrong formatting in release template (#100)
- S-87953 Remove optional OIDC and IS properties
- Dependencies were automatically synced.
- Dependencies were automatically synced.
- S-87974 xl kube --help improvements (#103)
- D-22926 "xl kube upgrade --files" fails when CR or CRD does not exist (#105)
- S-87867 (Backport) For Deploy, support separate configuration for main and report DB
