### PR TITLE
S-88585 Backport Support for custom Image Registry

### DIFF
--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -8,22 +8,46 @@ metadata:
   version: 1.0
 spec:
   parameters:
-    - name: IsCustomImageRegistry
-      type: Confirm
-      saveInXlvals: true
+    - name: ImageRegistryType
+      type: Select
+      prompt: "Select the type of Image Registry:"
+      options:
+        - label: Default (Uses various default public image registries for the images)
+          value: default
+        - label: Custom Public Registry (Overrides defaults to use a specific custom public registry)
+          value: public
+        - label: Custom Private Registry - Password protected (Overrides defaults to use a specific custom private registry)
+          value: private
+      promptIf: !expr "ProcessType == 'install' || ProcessType == 'upgrade'"
       ignoreIfSkipped: true
-      overrideDefault: true
-      prompt: "Do you want to use a custom docker image registry"
-      default: false
-      description: Do you want installer to use a private image registry for pulling all the images required for this installation
+      saveInXlvals: true
+      default: DefaultImageRegistry
+      description: Select the type of the Image Registry to use for pulling all images required for the installation.
     - name: CustomImageRegistryName
       type: Input
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      promptIf: !expr "IsCustomImageRegistry == true"
-      prompt: "Enter the custom docker image registry hostname"
-      description: Enter the private image registry host for pulling all the images required for this installation  
+      promptIf: !expr "ImageRegistryType == 'public' || ImageRegistryType == 'private' && (ProcessType == 'install' || ProcessType == 'upgrade')"
+      prompt: "Enter the custom docker image registry name"
+      description: Enter the custom image registry name for pulling all the images required for this installation
+    - name: CustomPrivateImageRegistrySecret
+      type: Select
+      options:
+        - !expr k8sResources(Namespace, 'secrets')
+      saveInXlvals: true
+      ignoreIfSkipped: true
+      overrideDefault: true
+      prompt: "Provide the custom docker image registry secret"
+      promptIf: !expr "ImageRegistryType == 'private' && (ProcessType == 'install' || ProcessType == 'upgrade')"
+      description: Provide the imagePullSecrets name for the custom image registry
+    - name: IsCustomImageRegistry
+      type: Confirm
+      saveInXlvals: true
+      ignoreIfSkipped: true
+      value: !expr "ImageRegistryType == 'public' || ImageRegistryType == 'private' ? true : false"
+      description: Is Custom Image Repository
+      default: true          
     - name: RepositoryName
       type: Input
       saveInXlvals: true
@@ -32,7 +56,7 @@ spec:
       promptIf: !expr "ProcessType == 'install' || ProcessType == 'upgrade'"
       prompt: "Enter the repository name (eg: <repositoryName> from <repositoryName>/<imageName>:<tagName>):"
       default: xebialabsunsupported
-      description: Enter the repository name to use
+      description: Enter the repository name to use. When using custom Image Registry, enter <imageRegistryName>/<repositoryName>
     - name: ImageNameDeploy
       type: Input
       saveInXlvals: true

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -23,12 +23,19 @@ spec:
       saveInXlvals: true
       default: DefaultImageRegistry
       description: Select the type of the Image Registry to use for pulling all images required for the installation.
+    - name: IsCustomImageRegistry
+      type: Confirm
+      saveInXlvals: true
+      ignoreIfSkipped: true
+      value: !expr "ImageRegistryType == 'public' || ImageRegistryType == 'private' ? true : false"
+      description: Is Custom Image Repository
+      default: true
     - name: CustomImageRegistryName
       type: Input
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      promptIf: !expr "ImageRegistryType == 'public' || ImageRegistryType == 'private' && (ProcessType == 'install' || ProcessType == 'upgrade')"
+      promptIf: !expr "IsCustomImageRegistry && (ProcessType == 'install' || ProcessType == 'upgrade')"
       prompt: "Enter the custom docker image registry name"
       description: Enter the custom image registry name for pulling all the images required for this installation
     - name: CustomPrivateImageRegistrySecret
@@ -39,24 +46,17 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       prompt: "Provide the custom docker image registry secret"
-      promptIf: !expr "ImageRegistryType == 'private' && (ProcessType == 'install' || ProcessType == 'upgrade')"
+      promptIf: !expr "(ImageRegistryType == 'private') && (ProcessType == 'install' || ProcessType == 'upgrade')"
       description: Provide the imagePullSecrets name for the custom image registry
-    - name: IsCustomImageRegistry
-      type: Confirm
-      saveInXlvals: true
-      ignoreIfSkipped: true
-      value: !expr "ImageRegistryType == 'public' || ImageRegistryType == 'private' ? true : false"
-      description: Is Custom Image Repository
-      default: true          
     - name: RepositoryName
       type: Input
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
       promptIf: !expr "ProcessType == 'install' || ProcessType == 'upgrade'"
-      prompt: "Enter the repository name (eg: <repositoryName> from <repositoryName>/<imageName>:<tagName>). For Custom Image Registry enter <imageRegistryName>/<repositoryName>: "
-      default: xebialabsunsupported
-      description: Enter the repository name to use. When using custom Image Registry, enter <imageRegistryName>/<repositoryName>
+      prompt: !expr "IsCustomImageRegistry ? 'Enter the repository name (eg: <imageRegistryName>/<repositoryName> from <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):' : 'Enter the repository name (eg: <repositoryName> from <repositoryName>/<imageName>:<tagName>):'"
+      default: !expr "IsCustomImageRegistry ? CustomImageRegistryName+'/xebialabsunsupported' : 'xebialabsunsupported'"
+      description: Enter the repository name to use
     - name: ImageNameDeploy
       type: Input
       saveInXlvals: true
@@ -428,7 +428,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
+      prompt: !expr "IsCustomImageRegistry ? 'Enter the operator image to use (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):' : 'Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):'"
       promptIf: !expr ServerType == 'dai-deploy' && K8sSetup != 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/deploy-operator:23.1.0-beta.6
       description: Enter the operator image to use
@@ -437,7 +437,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
+      prompt: !expr "IsCustomImageRegistry ? 'Enter the operator image to use (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):' : 'Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):'"
       promptIf: !expr ServerType == 'dai-deploy' && K8sSetup == 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/deploy-operator:23.1.0-beta.6-openshift
       description: Enter the operator image to use
@@ -446,7 +446,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
+      prompt: !expr "IsCustomImageRegistry ? 'Enter the operator image to use (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):' : 'Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):'"
       promptIf: !expr ServerType == 'dai-release' && K8sSetup != 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/release-operator:23.1.0-beta.6
       description: Enter the operator image to use
@@ -455,7 +455,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
+      prompt: !expr "IsCustomImageRegistry ? 'Enter the operator image to use (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):' : 'Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):'"
       promptIf: !expr ServerType == 'dai-release' && K8sSetup == 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/release-operator:23.1.0-beta.6-openshift
       description: Enter the operator image to use

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -21,7 +21,7 @@ spec:
       promptIf: !expr "ProcessType == 'install' || ProcessType == 'upgrade'"
       ignoreIfSkipped: true
       saveInXlvals: true
-      default: DefaultImageRegistry
+      default: default
       description: Select the type of the Image Registry to use for pulling all images required for the installation.
     - name: IsCustomImageRegistry
       type: Confirm

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -54,7 +54,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       promptIf: !expr "ProcessType == 'install' || ProcessType == 'upgrade'"
-      prompt: "Enter the repository name (eg: <repositoryName> from <repositoryName>/<imageName>:<tagName>):"
+      prompt: "Enter the repository name (eg: <repositoryName> from <repositoryName>/<imageName>:<tagName>). For Custom Image Registry enter <imageRegistryName>/<repositoryName>: "
       default: xebialabsunsupported
       description: Enter the repository name to use. When using custom Image Registry, enter <imageRegistryName>/<repositoryName>
     - name: ImageNameDeploy
@@ -428,7 +428,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):"
+      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
       promptIf: !expr ServerType == 'dai-deploy' && K8sSetup != 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/deploy-operator:23.1.0-beta.6
       description: Enter the operator image to use
@@ -437,7 +437,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):"
+      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
       promptIf: !expr ServerType == 'dai-deploy' && K8sSetup == 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/deploy-operator:23.1.0-beta.6-openshift
       description: Enter the operator image to use
@@ -446,7 +446,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):"
+      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
       promptIf: !expr ServerType == 'dai-release' && K8sSetup != 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/release-operator:23.1.0-beta.6
       description: Enter the operator image to use
@@ -455,7 +455,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>):"
+      prompt: "Enter the operator image to use (eg: <repositoryName>/<imageName>:<tagName>). For Custom Image Registry (eg: <imageRegistryName>/<repositoryName>/<imageName>:<tagName>):"
       promptIf: !expr ServerType == 'dai-release' && K8sSetup == 'Openshift' && (ProcessType == 'install' || ProcessType == 'upgrade')
       default: xebialabsunsupported/release-operator:23.1.0-beta.6-openshift
       description: Enter the operator image to use

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -8,6 +8,22 @@ metadata:
   version: 1.0
 spec:
   parameters:
+    - name: IsCustomImageRegistry
+      type: Confirm
+      saveInXlvals: true
+      ignoreIfSkipped: true
+      overrideDefault: true
+      prompt: "Do you want to use a custom docker image registry"
+      default: false
+      description: Do you want installer to use a private image registry for pulling all the images required for this installation
+    - name: CustomImageRegistryName
+      type: Input
+      saveInXlvals: true
+      ignoreIfSkipped: true
+      overrideDefault: true
+      promptIf: !expr "IsCustomImageRegistry == true"
+      prompt: "Enter the custom docker image registry hostname"
+      description: Enter the private image registry host for pulling all the images required for this installation  
     - name: RepositoryName
       type: Input
       saveInXlvals: true

--- a/xl-op/blueprint.yaml
+++ b/xl-op/blueprint.yaml
@@ -36,7 +36,7 @@ spec:
       ignoreIfSkipped: true
       overrideDefault: true
       promptIf: !expr "IsCustomImageRegistry && (ProcessType == 'install' || ProcessType == 'upgrade')"
-      prompt: "Enter the custom docker image registry name"
+      prompt: "Enter the custom docker image registry name:"
       description: Enter the custom image registry name for pulling all the images required for this installation
     - name: CustomPrivateImageRegistrySecret
       type: Select
@@ -45,7 +45,7 @@ spec:
       saveInXlvals: true
       ignoreIfSkipped: true
       overrideDefault: true
-      prompt: "Provide the custom docker image registry secret"
+      prompt: "Provide the custom docker image registry secret:"
       promptIf: !expr "(ImageRegistryType == 'private') && (ProcessType == 'install' || ProcessType == 'upgrade')"
       description: Provide the imagePullSecrets name for the custom image registry
     - name: RepositoryName

--- a/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
@@ -140,7 +140,10 @@ spec:
         {{- end }}
         tag: v0.13.4
       {{- if eq .ImageRegistryType "private" }}
-      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }}
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
       {{- if eq .UseCustomNamespace true }}
       ingressClass: haproxy-dai-xld-{{ .Namespace }}
@@ -1028,6 +1031,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
     hostAliases: []
     hostNetwork: false
@@ -1236,6 +1241,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}    
       postgresql:
         existingSecret: ""
@@ -1678,14 +1685,15 @@ spec:
       {{- /* global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
       imageRegistry: {{ .CustomImageRegistryName }}
-      storageClass: ""
       {{- else }}
       imageRegistry: ""
-      storageClass: ""
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
+      storageClass: ""
     hostAliases: []
     image:
       debug: false

--- a/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
@@ -19,10 +19,16 @@ spec:
   ImageTag: "{{ .ImageTag }}"
   ## xebialabs/tiny-tools image version
   ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  {{- if eq .IsCustomImageRegistry true }}
+  TinyToolsImageRepository: "{{ .RepositoryName }}/tiny-tools"
+  {{- else }}  
   TinyToolsImageRepository: "xebialabs/tiny-tools"
+  {{- end }}
   TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
-  # ImagePullSecret: xlDeploy
+  {{- if eq .ImageRegistryType "private" }}
+  ImagePullSecret: {{ .CustomPrivateImageRegistrySecret }}
+  {{- end }}
   K8sSetup:
     Platform: {{ .K8sSetup }}
   KeystorePassphrase: '{{ .KeystorePassphrase }}'
@@ -127,9 +133,15 @@ spec:
       hostNetwork: false
       image:
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        repository: {{ .RepositoryName }}/haproxy-ingress
+        {{- else }}        
         repository: quay.io/jcmoraisjr/haproxy-ingress
+        {{- end }}
         tag: v0.13.4
-      imagePullSecrets: []
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
       {{- if eq .UseCustomNamespace true }}
       ingressClass: haproxy-dai-xld-{{ .Namespace }}
       {{- else }}
@@ -456,9 +468,18 @@ spec:
     hostAliases: []
     image:
       pullPolicy: IfNotPresent
+      {{- if eq .IsCustomImageRegistry true }}
+      repository: {{ .RepositoryName }}/keycloak
+      {{- else}}      
       repository: docker.io/jboss/keycloak
+      {{- end }}
       tag: ""
+    {{- if eq .ImageRegistryType "private" }}
+    imagePullSecrets: 
+      - name: {{ .CustomPrivateImageRegistrySecret }}
+    {{- else }}
     imagePullSecrets: []
+    {{- end }}      
     ingress:
       annotations:
         {{- if eq .UseCustomNamespace true }}
@@ -551,9 +572,21 @@ spec:
       image:
         debug: false
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgresql
+        {{- else }}        
         registry: docker.io
         repository: bitnami/postgresql
+        {{- end }}
         tag: 11.11.0-debian-10-r31
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
+      {{- end }}        
       ldap:
         baseDN: ""
         bind_password: null
@@ -580,8 +613,14 @@ spec:
         extraEnvVars: {}
         image:
           pullPolicy: IfNotPresent
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/postgres-exporter
+          {{- else }}          
           registry: docker.io
           repository: bitnami/postgres-exporter
+          {{- end }}          
           tag: 0.9.0-debian-10-r6
         livenessProbe:
           enabled: true
@@ -742,8 +781,14 @@ spec:
         enabled: false
         image:
           pullPolicy: Always
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/bitnami-shell
+          {{- else }}          
           registry: docker.io
           repository: bitnami/bitnami-shell
+          {{- end }}
           tag: "10"
         securityContext:
           runAsUser: 0
@@ -892,8 +937,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/nginx
+        {{- else }}        
         registry: docker.io
         repository: bitnami/nginx
+        {{- end }}
         tag: 1.21.3-debian-10-r48
       livenessProbe:
         enabled: true
@@ -969,15 +1020,28 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      {{- else }}
       imageRegistry: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
     hostAliases: []
     hostNetwork: false
     image:
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/nginx-ingress-controller
+      {{- else }}      
       registry: docker.io
       repository: bitnami/nginx-ingress-controller
+      {{- end }}
       tag: 1.0.4-debian-10-r13
     {{- if eq .UseCustomNamespace true }}
     ingressClassResource:
@@ -1164,8 +1228,15 @@ spec:
     extraEnvVarsCM: ""
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /*  global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      {{- else }}
       imageRegistry: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}    
       postgresql:
         existingSecret: ""
         postgresqlDatabase: ""
@@ -1178,8 +1249,14 @@ spec:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/postgresql
+      {{- else }}      
       registry: docker.io
       repository: bitnami/postgresql
+      {{- end }}
       tag: 11.13.0-debian-10-r73
     initdbPassword: ""
     initdbScripts: {}
@@ -1216,8 +1293,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgres-exporter
+        {{- else }}        
         registry: docker.io
         repository: bitnami/postgres-exporter
+        {{- end }}
         tag: 0.10.0-debian-10-r101
       livenessProbe:
         enabled: true
@@ -1420,8 +1503,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}        
         tag: 10-debian-10-r233
       securityContext:
         runAsUser: 0
@@ -1586,16 +1675,30 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      storageClass: ""
+      {{- else }}
       imageRegistry: ""
       storageClass: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
     hostAliases: []
     image:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/rabbitmq
+      {{- else }}      
       registry: docker.io
       repository: bitnami/rabbitmq
+      {{- end }}
       tag: 3.9.8-debian-10-r6
     ingress:
       annotations: {}
@@ -1754,8 +1857,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}        
         tag: 10-debian-10-r233
       resources:
         limits: {}

--- a/xl-op/digitalai/dai-deploy/kubernetes-generic/template/deployment.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-generic/template/deployment.yaml.tmpl
@@ -14,9 +14,17 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name: {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}    
       containers:
       - name: kube-rbac-proxy
+        {{- if eq .IsCustomImageRegistry true }}
+        image: {{ .RepositoryName }}/kube-rbac-proxy:v0.8.0
+        {{- else }}      
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        {{- end }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/xl-op/digitalai/dai-deploy/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
@@ -17,9 +17,17 @@ spec:
       name: dai-xld-postgresql-init-keycloak-db
       {{- end }}
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name:  {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}      
       initContainers:
         - name: wait-for-postgresql
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c
@@ -39,7 +47,11 @@ spec:
               value: "5432"
       containers:
         - name: postgresql-init-keycloak-db
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c

--- a/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
@@ -224,7 +224,7 @@ spec:
       tag: ""
     {{- if eq .ImageRegistryType "private" }}
     imagePullSecrets: 
-      - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      - name: {{ .CustomPrivateImageRegistrySecret }}
     {{- else }}      
     imagePullSecrets: []
     {{- end }}

--- a/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
@@ -19,8 +19,15 @@ spec:
   ImageTag: "{{ .ImageTag }}"
   ## xebialabs/tiny-tools image version
   ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  {{- if eq .IsCustomImageRegistry true }}
+  TinyToolsImageRepository: "{{ .RepositoryName }}/tiny-tools"
+  {{- else }}
   TinyToolsImageRepository: "xebialabs/tiny-tools"
+  {{- end }}
   TinyToolsImageTag: "22.2.0"
+  {{- if eq .ImageRegistryType "private" }}
+  ImagePullSecret: {{ .CustomPrivateImageRegistrySecret }}
+  {{- end }}
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   KeystorePassphrase: '{{ .KeystorePassphrase }}'
@@ -209,9 +216,18 @@ spec:
     hostAliases: []
     image:
       pullPolicy: IfNotPresent
+      {{- if eq .IsCustomImageRegistry true }}
+      repository: {{ .RepositoryName }}/keycloak
+      {{- else}}      
       repository: docker.io/jboss/keycloak
+      {{- end }}
       tag: ""
+    {{- if eq .ImageRegistryType "private" }}
+    imagePullSecrets: 
+      - name: {{ .CustomPrivateImageRegistrySecret }} ]
+    {{- else }}      
     imagePullSecrets: []
+    {{- end }}
     ingress:
       annotations: {}
       console:
@@ -298,9 +314,21 @@ spec:
       image:
         debug: false
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgresql
+        {{- else }}        
         registry: docker.io
         repository: bitnami/postgresql
+        {{- end }}
         tag: 11.11.0-debian-10-r31
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
+      {{- end }}
       ldap:
         baseDN: ""
         bind_password: null
@@ -327,8 +355,14 @@ spec:
         extraEnvVars: {}
         image:
           pullPolicy: IfNotPresent
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/postgres-exporter
+          {{- else }}          
           registry: docker.io
           repository: bitnami/postgres-exporter
+          {{- end }}
           tag: 0.9.0-debian-10-r6
         livenessProbe:
           enabled: true
@@ -489,8 +523,14 @@ spec:
         enabled: false
         image:
           pullPolicy: Always
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/bitnami-shell
+          {{- else }}          
           registry: docker.io
           repository: bitnami/bitnami-shell
+          {{- end }}           
           tag: "10"
         securityContext:
           runAsUser: 0
@@ -632,8 +672,15 @@ spec:
     extraEnvVarsCM: ""
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      {{- else }}    
       imageRegistry: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
       postgresql:
         existingSecret: ""
         postgresqlDatabase: ""
@@ -646,8 +693,14 @@ spec:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/postgresql
+      {{- else }}      
       registry: docker.io
       repository: bitnami/postgresql
+      {{- end }}
       tag: 11.13.0-debian-10-r73
     initdbPassword: ""
     initdbScripts: {}
@@ -684,8 +737,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgres-exporter
+        {{- else }}        
         registry: docker.io
         repository: bitnami/postgres-exporter
+        {{- end }}
         tag: 0.10.0-debian-10-r101
       livenessProbe:
         enabled: true
@@ -888,8 +947,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}
         tag: 10-debian-10-r233
       securityContext:
         runAsUser: auto
@@ -1054,16 +1119,30 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      storageClass: ""
+      {{- else }}    
       imageRegistry: ""
       storageClass: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
     hostAliases: []
     image:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/rabbitmq
+      {{- else }}      
       registry: docker.io
       repository: bitnami/rabbitmq
+      {{- end }}
       tag: 3.9.8-debian-10-r6
     ingress:
       annotations: {}
@@ -1222,8 +1301,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}          
         tag: 10-debian-10-r233
       resources:
         limits: {}

--- a/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-openshift/dai-deploy_cr_default.yaml.tmpl
@@ -680,6 +680,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
       postgresql:
         existingSecret: ""
@@ -1122,14 +1124,15 @@ spec:
       {{- /* global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
       imageRegistry: {{ .CustomImageRegistryName }}
-      storageClass: ""
       {{- else }}    
       imageRegistry: ""
-      storageClass: ""
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}    
+      imagePullSecrets: []
       {{- end }}
+      storageClass: ""
     hostAliases: []
     image:
       debug: false

--- a/xl-op/digitalai/dai-deploy/kubernetes-openshift/template/deployment.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-openshift/template/deployment.yaml.tmpl
@@ -14,9 +14,17 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name: {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}      
       containers:
       - name: kube-rbac-proxy
+        {{- if eq .IsCustomImageRegistry true }}
+        image: {{ .RepositoryName }}/kube-rbac-proxy:v0.8.0
+        {{- else }}      
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        {{- end }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/xl-op/digitalai/dai-deploy/kubernetes-openshift/template/postgresql-init-keycloak-db.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-openshift/template/postgresql-init-keycloak-db.yaml.tmpl
@@ -17,9 +17,17 @@ spec:
       name: dai-ocp-xld-postgresql-init-keycloak-db
       {{- end }}
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name:  {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}    
       initContainers:
         - name: wait-for-postgresql
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}          
           command:
             - sh
             - -c
@@ -39,7 +47,11 @@ spec:
               value: "5432"
       containers:
         - name: postgresql-init-keycloak-db
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c

--- a/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
@@ -18,10 +18,16 @@ spec:
   ImageTag: "{{ .ImageTag }}"
   ## xebialabs/tiny-tools image version
   ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  {{- if eq .IsCustomImageRegistry true }}
+  TinyToolsImageRepository: "{{ .RepositoryName }}/tiny-tools"
+  {{- else }}
   TinyToolsImageRepository: "xebialabs/tiny-tools"
+  {{- end }}
   TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
+  # {{- if eq .IsCustomImageRegistry true }}
   # ImagePullSecret: xlRelease
+  # {{- end }}
   K8sSetup:
     Platform: {{ .K8sSetup }}
   KeystorePassphrase: '{{ .KeystorePassphrase }}'
@@ -112,7 +118,11 @@ spec:
       hostNetwork: false
       image:
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        repository: {{ .RepositoryName }}/haproxy-ingress
+        {{- else }}
         repository: quay.io/jcmoraisjr/haproxy-ingress
+        {{- end }}
         tag: v0.13.4
       imagePullSecrets: []
       {{- if eq .UseCustomNamespace true }}
@@ -441,7 +451,11 @@ spec:
     hostAliases: []
     image:
       pullPolicy: IfNotPresent
+      {{- if eq .IsCustomImageRegistry true }}
+      repository: {{ .RepositoryName }}/keycloak
+      {{- else}}
       repository: docker.io/jboss/keycloak
+      {{- end }}
       tag: ""
     imagePullSecrets: []
     ingress:
@@ -537,8 +551,15 @@ spec:
       image:
         debug: false
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        registry: {{ .CustomImageRegistryName }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgresql
+        {{- else }}
         registry: docker.io
         repository: bitnami/postgresql
+        {{- end }}
         tag: 11.11.0-debian-10-r31
       ldap:
         baseDN: ""
@@ -824,6 +845,9 @@ spec:
     tolerations: []
     topologySpreadConstraints: null
   nginx-ingress-controller:
+    global:
+      imageRegistry: {{ .CustomImageRegistryName }}
+      imagePullSecrets: []
     addHeaders: {}
     affinity: {}
     args: []
@@ -1107,6 +1131,11 @@ spec:
     enabled: {{ not (eq .OidcConfigType "no-oidc") }}
 {{ .ExternalOidcConf | indent 4 }}
   postgresql:
+    {{- if eq .IsCustomImageRegistry true }}
+    global:      
+      imageRegistry: {{ .CustomImageRegistryName }}
+      imagePullSecrets: []
+    {{- end }}
     audit:
       clientMinMessages: error
       logConnections: false
@@ -1412,6 +1441,11 @@ spec:
       securityContext:
         runAsUser: 0
   rabbitmq:
+    {{- if eq .IsCustomImageRegistry true }}
+    global:      
+      imageRegistry: {{ .CustomImageRegistryName }}
+      imagePullSecrets: []
+    {{- end }}
     advancedConfiguration: ""
     affinity: {}
     args: []

--- a/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
@@ -25,9 +25,9 @@ spec:
   {{- end }}
   TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
-  # {{- if eq .IsCustomImageRegistry true }}
-  # ImagePullSecret: xlRelease
-  # {{- end }}
+  {{- if eq .ImageRegistryType "private" }}
+  ImagePullSecret: {{ .CustomPrivateImageRegistrySecret }}
+  {{- end }}
   K8sSetup:
     Platform: {{ .K8sSetup }}
   KeystorePassphrase: '{{ .KeystorePassphrase }}'
@@ -124,7 +124,9 @@ spec:
         repository: quay.io/jcmoraisjr/haproxy-ingress
         {{- end }}
         tag: v0.13.4
-      imagePullSecrets: []
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
       {{- if eq .UseCustomNamespace true }}
       ingressClass: haproxy-dai-xlr-{{ .Namespace }}
       {{- else }}
@@ -457,7 +459,12 @@ spec:
       repository: docker.io/jboss/keycloak
       {{- end }}
       tag: ""
+    {{- if eq .ImageRegistryType "private" }}
+    imagePullSecrets: 
+      - name: {{ .CustomPrivateImageRegistrySecret }}
+    {{- else }}
     imagePullSecrets: []
+    {{- end }}
     ingress:
       annotations:
         {{- if eq .UseCustomNamespace true }}
@@ -552,7 +559,6 @@ spec:
         debug: false
         pullPolicy: IfNotPresent
         {{- if eq .IsCustomImageRegistry true }}
-        # registry: "{{ .CustomImageRegistryName }}"
         {{- /* repository name contains image registry hostname also */}}
         {{- $repoName := split "/" .RepositoryName }}
         repository: {{ $repoName._1 }}/postgresql
@@ -561,6 +567,12 @@ spec:
         repository: bitnami/postgresql
         {{- end }}
         tag: 11.11.0-debian-10-r31
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
+      {{- end }}
       ldap:
         baseDN: ""
         bind_password: null
@@ -588,7 +600,6 @@ spec:
         image:
           pullPolicy: IfNotPresent
           {{- if eq .IsCustomImageRegistry true }}
-          # registry: "{{ .CustomImageRegistryName }}"
           {{- /* repository name contains image registry hostname also */}}
           {{- $repoName := split "/" .RepositoryName }}
           repository: {{ $repoName._1 }}/postgres-exporter
@@ -757,7 +768,6 @@ spec:
         image:
           pullPolicy: Always
           {{- if eq .IsCustomImageRegistry true }}
-          # registry: "{{ .CustomImageRegistryName }}"
           {{- /* repository name contains image registry hostname also */}}
           {{- $repoName := split "/" .RepositoryName }}
           repository: {{ $repoName._1 }}/bitnami-shell
@@ -916,7 +926,6 @@ spec:
         {{- if eq .IsCustomImageRegistry true }}
         {{- /* repository name contains image registry hostname also */}}
         {{- $repoName := split "/" .RepositoryName }}
-        # registry: {{ .CustomImageRegistryName }}
         repository: {{ $repoName._1 }}/nginx
         {{- else }}
         registry: docker.io
@@ -997,13 +1006,14 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      {{- /* overrides the image registry hostname specified elsewhere for nginx-ingress-controller */}}
+      {{- /* global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
       imageRegistry: {{ .CustomImageRegistryName }}
-      imagePullSecrets: []
       {{- else }}
-      imagePullSecrets: []
       imageRegistry: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
       {{- end }}
     hostAliases: []
     hostNetwork: false
@@ -1013,7 +1023,6 @@ spec:
       {{- if eq .IsCustomImageRegistry true }}
       {{- /* repository name contains image registry hostname also */}}
       {{- $repoName := split "/" .RepositoryName }}
-      # registry: {{ .CustomImageRegistryName }}
       repository: {{ $repoName._1 }}/nginx-ingress-controller
       {{- else }}
       registry: docker.io
@@ -1162,7 +1171,6 @@ spec:
     enabled: {{ not (eq .OidcConfigType "no-oidc") }}
 {{ .ExternalOidcConf | indent 4 }}
   postgresql:
-
     audit:
       clientMinMessages: error
       logConnections: false
@@ -1206,14 +1214,15 @@ spec:
     extraEnvVarsCM: ""
     fullnameOverride: ""
     global:
-      {{- /* overrides the image registry hostname specified elsewhere for postgres */}}
+      {{- /*  global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
       imageRegistry: {{ .CustomImageRegistryName }}
-      imagePullSecrets: []
       {{- else }}
-      imagePullSecrets: []
       imageRegistry: ""
       {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}      
       postgresql:
         existingSecret: ""
         postgresqlDatabase: ""
@@ -1229,7 +1238,6 @@ spec:
       {{- if eq .IsCustomImageRegistry true }}
       {{- /* repository name contains image registry hostname also */}}
       {{- $repoName := split "/" .RepositoryName }}
-      # registry: {{ .CustomImageRegistryName }}
       repository: {{ $repoName._1 }}/postgresql
       {{- else }}
       registry: docker.io
@@ -1271,8 +1279,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgres-exporter
+        {{- else }}
         registry: docker.io
         repository: bitnami/postgres-exporter
+        {{- end }}        
         tag: 0.10.0-debian-10-r101
       livenessProbe:
         enabled: true
@@ -1476,7 +1490,6 @@ spec:
         pullPolicy: IfNotPresent
         pullSecrets: []
         {{- if eq .IsCustomImageRegistry true }}
-        # registry: "{{ .CustomImageRegistryName }}"
         {{- /* repository name contains image registry hostname also */}}
         {{- $repoName := split "/" .RepositoryName }}
         repository: {{ $repoName._1 }}/bitnami-shell
@@ -1648,23 +1661,23 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      {{- /* overrides the image registry hostname specified elsewhere for postgres */}}
+      {{- /* global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
-      imagePullSecrets: []
       imageRegistry: {{ .CustomImageRegistryName }}
       storageClass: ""
       {{- else }}
-      imagePullSecrets: []
       imageRegistry: ""
       storageClass: ""
       {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}      
     hostAliases: []
     image:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
       {{- if eq .IsCustomImageRegistry true }}
-      # registry: {{ .CustomImageRegistryName }}
       {{- /* repository name contains image registry hostname also */}}
       {{- $repoName := split "/" .RepositoryName }}
       repository: {{ $repoName._1 }}/rabbitmq
@@ -1831,7 +1844,6 @@ spec:
         pullPolicy: IfNotPresent
         pullSecrets: []
         {{- if eq .IsCustomImageRegistry true }}
-        # registry: "{{ .CustomImageRegistryName }}"
         {{- /* repository name contains image registry hostname also */}}
         {{- $repoName := split "/" .RepositoryName }}
         repository: {{ $repoName._1 }}/bitnami-shell

--- a/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
@@ -552,7 +552,7 @@ spec:
         debug: false
         pullPolicy: IfNotPresent
         {{- if eq .IsCustomImageRegistry true }}
-        registry: {{ .CustomImageRegistryName }}
+        # registry: "{{ .CustomImageRegistryName }}"
         {{- /* repository name contains image registry hostname also */}}
         {{- $repoName := split "/" .RepositoryName }}
         repository: {{ $repoName._1 }}/postgresql
@@ -587,8 +587,15 @@ spec:
         extraEnvVars: {}
         image:
           pullPolicy: IfNotPresent
+          {{- if eq .IsCustomImageRegistry true }}
+          # registry: "{{ .CustomImageRegistryName }}"
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/postgres-exporter
+          {{- else }}
           registry: docker.io
           repository: bitnami/postgres-exporter
+          {{- end }}          
           tag: 0.9.0-debian-10-r6
         livenessProbe:
           enabled: true
@@ -749,8 +756,15 @@ spec:
         enabled: false
         image:
           pullPolicy: Always
+          {{- if eq .IsCustomImageRegistry true }}
+          # registry: "{{ .CustomImageRegistryName }}"
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/bitnami-shell
+          {{- else }}
           registry: docker.io
           repository: bitnami/bitnami-shell
+          {{- end }}           
           tag: "10"
         securityContext:
           runAsUser: 0
@@ -845,9 +859,6 @@ spec:
     tolerations: []
     topologySpreadConstraints: null
   nginx-ingress-controller:
-    global:
-      imageRegistry: {{ .CustomImageRegistryName }}
-      imagePullSecrets: []
     addHeaders: {}
     affinity: {}
     args: []
@@ -902,8 +913,15 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        # registry: {{ .CustomImageRegistryName }}
+        repository: {{ $repoName._1 }}/nginx
+        {{- else }}
         registry: docker.io
         repository: bitnami/nginx
+        {{- end }}
         tag: 1.21.3-debian-10-r48
       livenessProbe:
         enabled: true
@@ -979,15 +997,28 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
+      {{- /* overrides the image registry hostname specified elsewhere for nginx-ingress-controller */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      imagePullSecrets: []
+      {{- else }}
       imagePullSecrets: []
       imageRegistry: ""
+      {{- end }}
     hostAliases: []
     hostNetwork: false
     image:
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      # registry: {{ .CustomImageRegistryName }}
+      repository: {{ $repoName._1 }}/nginx-ingress-controller
+      {{- else }}
       registry: docker.io
       repository: bitnami/nginx-ingress-controller
+      {{- end }}
       tag: 1.0.4-debian-10-r13
     {{- if eq .UseCustomNamespace true }}
     ingressClassResource:
@@ -1131,11 +1162,7 @@ spec:
     enabled: {{ not (eq .OidcConfigType "no-oidc") }}
 {{ .ExternalOidcConf | indent 4 }}
   postgresql:
-    {{- if eq .IsCustomImageRegistry true }}
-    global:      
-      imageRegistry: {{ .CustomImageRegistryName }}
-      imagePullSecrets: []
-    {{- end }}
+
     audit:
       clientMinMessages: error
       logConnections: false
@@ -1179,8 +1206,14 @@ spec:
     extraEnvVarsCM: ""
     fullnameOverride: ""
     global:
+      {{- /* overrides the image registry hostname specified elsewhere for postgres */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      imagePullSecrets: []
+      {{- else }}
       imagePullSecrets: []
       imageRegistry: ""
+      {{- end }}
       postgresql:
         existingSecret: ""
         postgresqlDatabase: ""
@@ -1193,8 +1226,15 @@ spec:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      # registry: {{ .CustomImageRegistryName }}
+      repository: {{ $repoName._1 }}/postgresql
+      {{- else }}
       registry: docker.io
       repository: bitnami/postgresql
+      {{- end }}
       tag: 11.13.0-debian-10-r73
     initdbPassword: ""
     initdbScripts: {}
@@ -1435,17 +1475,19 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        # registry: "{{ .CustomImageRegistryName }}"
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}        
         tag: 10-debian-10-r233
       securityContext:
         runAsUser: 0
   rabbitmq:
-    {{- if eq .IsCustomImageRegistry true }}
-    global:      
-      imageRegistry: {{ .CustomImageRegistryName }}
-      imagePullSecrets: []
-    {{- end }}
     advancedConfiguration: ""
     affinity: {}
     args: []
@@ -1606,16 +1648,30 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
+      {{- /* overrides the image registry hostname specified elsewhere for postgres */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imagePullSecrets: []
+      imageRegistry: {{ .CustomImageRegistryName }}
+      storageClass: ""
+      {{- else }}
       imagePullSecrets: []
       imageRegistry: ""
       storageClass: ""
+      {{- end }}
     hostAliases: []
     image:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      # registry: {{ .CustomImageRegistryName }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/rabbitmq
+      {{- else }}
       registry: docker.io
       repository: bitnami/rabbitmq
+      {{- end }}
       tag: 3.9.8-debian-10-r6
     ingress:
       annotations: {}
@@ -1774,8 +1830,15 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        # registry: "{{ .CustomImageRegistryName }}"
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}        
         tag: 10-debian-10-r233
       resources:
         limits: {}

--- a/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
@@ -125,7 +125,10 @@ spec:
         {{- end }}
         tag: v0.13.4
       {{- if eq .ImageRegistryType "private" }}
-      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
       {{- if eq .UseCustomNamespace true }}
       ingressClass: haproxy-dai-xlr-{{ .Namespace }}
@@ -1014,6 +1017,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
     hostAliases: []
     hostNetwork: false
@@ -1222,6 +1227,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}      
       postgresql:
         existingSecret: ""
@@ -1664,14 +1671,15 @@ spec:
       {{- /* global overrides the other occurences */}}
       {{- if eq .IsCustomImageRegistry true }}
       imageRegistry: {{ .CustomImageRegistryName }}
-      storageClass: ""
       {{- else }}
       imageRegistry: ""
-      storageClass: ""
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}      
+      storageClass: ""
     hostAliases: []
     image:
       debug: false

--- a/xl-op/digitalai/dai-release/kubernetes-generic/template/deployment.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/template/deployment.yaml.tmpl
@@ -16,7 +16,11 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
+        {{- if eq .IsCustomImageRegistry true }}
+        image: {{ .RepositoryName }}/kube-rbac-proxy:v0.8.0
+        {{- else }}
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        {{- end }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/xl-op/digitalai/dai-release/kubernetes-generic/template/deployment.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/template/deployment.yaml.tmpl
@@ -14,6 +14,10 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name: {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}    
       containers:
       - name: kube-rbac-proxy
         {{- if eq .IsCustomImageRegistry true }}

--- a/xl-op/digitalai/dai-release/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
@@ -19,7 +19,11 @@ spec:
     spec:
       initContainers:
         - name: wait-for-postgresql
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c
@@ -39,7 +43,11 @@ spec:
               value: "5432"
       containers:
         - name: postgresql-init-keycloak-db
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c

--- a/xl-op/digitalai/dai-release/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/template/postgresql-init-keycloak-db.yaml.tmpl
@@ -17,6 +17,10 @@ spec:
       name: dai-xlr-postgresql-init-keycloak-db
       {{- end }}
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name:  {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}    
       initContainers:
         - name: wait-for-postgresql
           {{- if eq .IsCustomImageRegistry true }}
@@ -47,7 +51,7 @@ spec:
           image: {{ .RepositoryName }}/tiny-tools:22.2.0
           {{- else }}
           image: xebialabs/tiny-tools:22.2.0
-          {{- end }}
+          {{- end }}          
           command:
             - sh
             - -c

--- a/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
@@ -18,8 +18,15 @@ spec:
   ImageTag: "{{ .ImageTag }}"
   ## xebialabs/tiny-tools image version
   ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  {{- if eq .IsCustomImageRegistry true }}
+  TinyToolsImageRepository: "{{ .RepositoryName }}/tiny-tools"
+  {{- else }}
   TinyToolsImageRepository: "xebialabs/tiny-tools"
+  {{- end }}
   TinyToolsImageTag: "22.2.0"
+  {{- if eq .ImageRegistryType "private" }}
+  ImagePullSecret: {{ .CustomPrivateImageRegistrySecret }}
+  {{- end }}
   KeystorePassphrase: '{{ .KeystorePassphrase }}'
   GenerateXlConfig: true
   MetricsEnabled: false
@@ -192,9 +199,18 @@ spec:
     hostAliases: []
     image:
       pullPolicy: IfNotPresent
+      {{- if eq .IsCustomImageRegistry true }}
+      repository: {{ .RepositoryName }}/keycloak
+      {{- else}}
       repository: docker.io/jboss/keycloak
+      {{- end }}
       tag: ""
+    {{- if eq .ImageRegistryType "private" }}
+    imagePullSecrets: 
+      - name: {{ .CustomPrivateImageRegistrySecret }} ]
+    {{- else }}
     imagePullSecrets: []
+    {{- end }}
     ingress:
       annotations: {}
       console:
@@ -282,9 +298,21 @@ spec:
       image:
         debug: false
         pullPolicy: IfNotPresent
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgresql
+        {{- else }}        
         registry: docker.io
         repository: bitnami/postgresql
+        {{- end }}
         tag: 11.11.0-debian-10-r31
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: 
+        - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
+      {{- end }}        
       ldap:
         baseDN: ""
         bind_password: null
@@ -311,8 +339,14 @@ spec:
         extraEnvVars: {}
         image:
           pullPolicy: IfNotPresent
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/postgres-exporter
+          {{- else }}
           registry: docker.io
           repository: bitnami/postgres-exporter
+          {{- end }}          
           tag: 0.9.0-debian-10-r6
         livenessProbe:
           enabled: true
@@ -473,8 +507,14 @@ spec:
         enabled: false
         image:
           pullPolicy: Always
+          {{- if eq .IsCustomImageRegistry true }}
+          {{- /* repository name contains image registry hostname also */}}
+          {{- $repoName := split "/" .RepositoryName }}
+          repository: {{ $repoName._1 }}/bitnami-shell
+          {{- else }}          
           registry: docker.io
           repository: bitnami/bitnami-shell
+          {{- end }}           
           tag: "10"
         securityContext:
           runAsUser: 0
@@ -616,8 +656,15 @@ spec:
     extraEnvVarsCM: ""
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      {{- else }}
       imageRegistry: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
       postgresql:
         existingSecret: ""
         postgresqlDatabase: ""
@@ -630,8 +677,14 @@ spec:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/postgresql
+      {{- else }}      
       registry: docker.io
       repository: bitnami/postgresql
+      {{- end }}
       tag: 11.13.0-debian-10-r73
     initdbPassword: ""
     initdbScripts: {}
@@ -668,8 +721,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/postgres-exporter
+        {{- else }}
         registry: docker.io
         repository: bitnami/postgres-exporter
+        {{- end }}
         tag: 0.10.0-debian-10-r101
       livenessProbe:
         enabled: true
@@ -872,8 +931,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}
         tag: 10-debian-10-r233
       securityContext:
         runAsUser: auto
@@ -1038,16 +1103,30 @@ spec:
     extraVolumes: []
     fullnameOverride: ""
     global:
-      imagePullSecrets: []
+      {{- /* global overrides the other occurences */}}
+      {{- if eq .IsCustomImageRegistry true }}
+      imageRegistry: {{ .CustomImageRegistryName }}
+      storageClass: ""
+      {{- else }}
       imageRegistry: ""
       storageClass: ""
+      {{- end }}
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- end }}
     hostAliases: []
     image:
       debug: false
       pullPolicy: IfNotPresent
       pullSecrets: []
+      {{- if eq .IsCustomImageRegistry true }}
+      {{- /* repository name contains image registry hostname also */}}
+      {{- $repoName := split "/" .RepositoryName }}
+      repository: {{ $repoName._1 }}/rabbitmq
+      {{- else }}      
       registry: docker.io
       repository: bitnami/rabbitmq
+      {{- end }}
       tag: 3.9.8-debian-10-r6
     ingress:
       annotations: {}
@@ -1206,8 +1285,14 @@ spec:
       image:
         pullPolicy: IfNotPresent
         pullSecrets: []
+        {{- if eq .IsCustomImageRegistry true }}
+        {{- /* repository name contains image registry hostname also */}}
+        {{- $repoName := split "/" .RepositoryName }}
+        repository: {{ $repoName._1 }}/bitnami-shell
+        {{- else }}        
         registry: docker.io
         repository: bitnami/bitnami-shell
+        {{- end }}        
         tag: 10-debian-10-r233
       resources:
         limits: {}

--- a/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
@@ -207,7 +207,7 @@ spec:
       tag: ""
     {{- if eq .ImageRegistryType "private" }}
     imagePullSecrets: 
-      - name: {{ .CustomPrivateImageRegistrySecret }} ]
+      - name: {{ .CustomPrivateImageRegistrySecret }}
     {{- else }}
     imagePullSecrets: []
     {{- end }}

--- a/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-openshift/dai-release_cr_default.yaml.tmpl
@@ -664,6 +664,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
       postgresql:
         existingSecret: ""
@@ -1113,6 +1115,8 @@ spec:
       {{- end }}
       {{- if eq .ImageRegistryType "private" }}
       imagePullSecrets: [ {{ .CustomPrivateImageRegistrySecret }} ]
+      {{- else }}
+      imagePullSecrets: []
       {{- end }}
     hostAliases: []
     image:

--- a/xl-op/digitalai/dai-release/kubernetes-openshift/template/deployment.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-openshift/template/deployment.yaml.tmpl
@@ -14,9 +14,17 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name: {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}       
       containers:
       - name: kube-rbac-proxy
+        {{- if eq .IsCustomImageRegistry true }}
+        image: {{ .RepositoryName }}/kube-rbac-proxy:v0.8.0
+        {{- else }}      
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        {{- end }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/xl-op/digitalai/dai-release/kubernetes-openshift/template/postgresql-init-keycloak-db.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-openshift/template/postgresql-init-keycloak-db.yaml.tmpl
@@ -17,9 +17,17 @@ spec:
       name: dai-ocp-xlr-postgresql-init-keycloak-db
       {{- end }}
     spec:
+      {{- if eq .ImageRegistryType "private" }}
+      imagePullSecrets:
+        - name:  {{ .CustomPrivateImageRegistrySecret }}
+      {{- end }}    
       initContainers:
         - name: wait-for-postgresql
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c
@@ -39,7 +47,11 @@ spec:
               value: "5432"
       containers:
         - name: postgresql-init-keycloak-db
+          {{- if eq .IsCustomImageRegistry true }}
+          image: {{ .RepositoryName }}/tiny-tools:22.2.0
+          {{- else }}        
           image: xebialabs/tiny-tools:22.2.0
+          {{- end }}
           command:
             - sh
             - -c

--- a/xl-op/digitalai/generated_answers.yaml.tmpl
+++ b/xl-op/digitalai/generated_answers.yaml.tmpl
@@ -3,6 +3,8 @@ UseCustomNamespace: {{ .UseCustomNamespace }}
 Namespace: {{ .Namespace }}
 ServerType: {{ .ServerType }}
 RepositoryName: {{ .RepositoryName }}
+IsCustomImageRegistry: {{ .IsCustomImageRegistry }}
+CustomImageRegistryName: {{ .CustomImageRegistryName }}
 ImageTag: {{ .ImageTag }}
 {{- if eq .ServerType "dai-deploy" }}
 ImageNameDeploy: {{ .ImageNameDeploy }}

--- a/xl-op/digitalai/generated_answers.yaml.tmpl
+++ b/xl-op/digitalai/generated_answers.yaml.tmpl
@@ -2,9 +2,15 @@ K8sSetup: {{ .K8sSetup }}
 UseCustomNamespace: {{ .UseCustomNamespace }}
 Namespace: {{ .Namespace }}
 ServerType: {{ .ServerType }}
-RepositoryName: {{ .RepositoryName }}
-IsCustomImageRegistry: {{ .IsCustomImageRegistry }}
+ImageRegistryType: {{ .ImageRegistryType }}
+{{- if eq .ImageRegistryType "public" }}
 CustomImageRegistryName: {{ .CustomImageRegistryName }}
+{{- end }}
+{{- if eq .ImageRegistryType "private" }}
+CustomImageRegistryName: {{ .CustomImageRegistryName }}
+CustomPrivateImageRegistrySecret: {{ .CustomPrivateImageRegistrySecret }}
+{{- end }}
+RepositoryName: {{ .RepositoryName }}
 ImageTag: {{ .ImageTag }}
 {{- if eq .ServerType "dai-deploy" }}
 ImageNameDeploy: {{ .ImageNameDeploy }}

--- a/xl-op/digitalai/generated_answers.yaml.tmpl
+++ b/xl-op/digitalai/generated_answers.yaml.tmpl
@@ -3,13 +3,8 @@ UseCustomNamespace: {{ .UseCustomNamespace }}
 Namespace: {{ .Namespace }}
 ServerType: {{ .ServerType }}
 ImageRegistryType: {{ .ImageRegistryType }}
-{{- if eq .ImageRegistryType "public" }}
-CustomImageRegistryName: {{ .CustomImageRegistryName }}
-{{- end }}
-{{- if eq .ImageRegistryType "private" }}
 CustomImageRegistryName: {{ .CustomImageRegistryName }}
 CustomPrivateImageRegistrySecret: {{ .CustomPrivateImageRegistrySecret }}
-{{- end }}
 RepositoryName: {{ .RepositoryName }}
 ImageTag: {{ .ImageTag }}
 {{- if eq .ServerType "dai-deploy" }}


### PR DESCRIPTION
- Support for custom Image Registry
- S-88585 Using global image registry to define custom image registry for bitnami chart dependencies.
- S-88585 CustomPrivate Registry Support Release & Deploy
- S-88585 Minor improvements to questions and corrected imagepullsecrets for keycloak
