### PR TITLE
D-27095 Plugin install with -f option failed in minikube

### DIFF
--- a/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-deploy/kubernetes-generic/dai-deploy_cr_default.yaml.tmpl
@@ -112,6 +112,7 @@ spec:
       kubernetes.io/ingress.class: nginx-dai-xld
       {{- end }}
       nginx.ingress.kubernetes.io/affinity: cookie
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "60"

--- a/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
+++ b/xl-op/digitalai/dai-release/kubernetes-generic/dai-release_cr_default.yaml.tmpl
@@ -98,6 +98,7 @@ spec:
       kubernetes.io/ingress.class: nginx-dai-xlr
       {{- end }}
       nginx.ingress.kubernetes.io/affinity: cookie
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
       nginx.ingress.kubernetes.io/proxy-connect-timeout: "120"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "120"


### PR DESCRIPTION
Haproxy needs no additional configuration as the default setting is already not checking the size: https://haproxy-ingress.github.io/docs/configuration/keys/#proxy-body-size